### PR TITLE
add support for xinclude directives (used by freedict eng-pol)

### DIFF
--- a/tei2slob/__init__.py
+++ b/tei2slob/__init__.py
@@ -157,16 +157,23 @@ class TEI:
                 ol.attrib['class'] += ' single'
 
     def __iter__(self):
-        for _, element in etree.iterparse(self.input_file):
+        input_files = [self.input_file]
+        while input_files:
+            for _, element in etree.iterparse(input_files.pop()):
 
-            if element.tag == TAG_HEADER:
-                yield from self._parse_header(element)
-                element.clear()
+                if element.tag == TAG_HEADER:
+                    yield from self._parse_header(element)
+                    element.clear()
 
-            if element.tag == TAG_ENTRY:
-                yield from self._parse_entry(element)
-                element.clear()
+                if element.tag == TAG_ENTRY:
+                    yield from self._parse_entry(element)
+                    element.clear()
 
+                if element.tag == '{http://www.w3.org/2001/XInclude}include':
+                    include_file = os.path.join(
+                            os.path.dirname(self.input_file),
+                            element.attrib['href'])
+                    input_files.append(include_file)
 
 
 def parse_args():

--- a/tei2slob/__init__.py
+++ b/tei2slob/__init__.py
@@ -48,6 +48,8 @@ TAG_HEADER = ns('teiHeader')
 
 TAG_ENTRY = ns('entry')
 
+TAG_INCLUDE = '{http://www.w3.org/2001/XInclude}include'
+
 
 def text(parent, path):
     element = parent.find(path, NS_MAP)
@@ -174,7 +176,7 @@ class TEI:
                     yield from self._parse_entry(element)
                     element.clear()
 
-                if element.tag == '{http://www.w3.org/2001/XInclude}include':
+                if element.tag == TAG_INCLUDE:
                     include_file = os.path.join(
                             os.path.dirname(self.input_file),
                             element.attrib['href'])


### PR DESCRIPTION
The tei2slob script looks great for many FreeDict dictionaries, but eng-pol.tei does not contain any useful data if the include directives are not executed. This change solves this problem.