### PR TITLE
Extract all text if subelements are present

### DIFF
--- a/tei2slob/__init__.py
+++ b/tei2slob/__init__.py
@@ -53,6 +53,8 @@ TAG_INCLUDE = '{http://www.w3.org/2001/XInclude}include'
 
 def text(parent, path):
     element = parent.find(path, NS_MAP)
+    if element is None:
+        return ''
     return ''.join(element.itertext())
 
 

--- a/tei2slob/__init__.py
+++ b/tei2slob/__init__.py
@@ -53,7 +53,7 @@ TAG_INCLUDE = '{http://www.w3.org/2001/XInclude}include'
 
 def text(parent, path):
     element = parent.find(path, NS_MAP)
-    return element.text if element is not None else ''
+    return ''.join(element.itertext())
 
 
 def attr(parent, path, attr_name):


### PR DESCRIPTION
The `text` function only extracts text via the element's `text` attribute. This returns only a part of the text when subelements are present:

>  If the element is created from an XML file, the text attribute holds either the text between the element’s start tag and its first child or end tag, or None

see https://docs.python.org/2/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.text

I've fixed this by iterating over all text elements in that element/subtree.