### PR TITLE
Avoid crashes on nodes without text

### DIFF
--- a/tei2slob/__init__.py
+++ b/tei2slob/__init__.py
@@ -53,8 +53,9 @@ TAG_INCLUDE = '{http://www.w3.org/2001/XInclude}include'
 
 def text(parent, path):
     element = parent.find(path, NS_MAP)
-    return element.text if element is not None and element.text is not None\
-            else ''
+    if element is not None and element.text:
+        return element.text
+    return ''
 
 
 def attr(parent, path, attr_name):

--- a/tei2slob/__init__.py
+++ b/tei2slob/__init__.py
@@ -53,7 +53,8 @@ TAG_INCLUDE = '{http://www.w3.org/2001/XInclude}include'
 
 def text(parent, path):
     element = parent.find(path, NS_MAP)
-    return element.text if element is not None else ''
+    return element.text if element is not None and element.text is not None\
+            else ''
 
 
 def attr(parent, path, attr_name):


### PR DESCRIPTION
Missing information, such as the copyright holder, could lead to a
crash. An empty string is more appropriate.